### PR TITLE
Configure datadog (and add missing mongo upgrade)

### DIFF
--- a/kubernetes/charts/add_helm_repos.sh
+++ b/kubernetes/charts/add_helm_repos.sh
@@ -3,4 +3,5 @@ helm repo add nginx-stable https://helm.nginx.com/stable
 helm repo add jetstack https://charts.jetstack.io # cert-manager
 helm repo add trino https://trinodb.github.io/charts/
 helm repo add bitnami https://charts.bitnami.com/bitnami # mongodb, grafana but many charts available
+helm repo add datadog https://helm.datadoghq.com
 helm repo update

--- a/kubernetes/charts/install.sh
+++ b/kubernetes/charts/install.sh
@@ -11,10 +11,16 @@ helm install nt-trino trino/
 if [ -z "$MONGODB_ROOT_PASSWORD" -o -z "$MONGO_USR" -o -z "$MONGO_PW" ]; then
   echo "Cowardly refusing to configure MongoDB without auth config."
 else
-  helm install mongo001 mongodb/ --set "auth.rootPassword=$MONGO_ROOT_PASSWORD,auth.username=$MONGO_USR,auth.password=$MONGO_PW,auth.database=ktest"
+  helm install mongo001 mongodb/ --set "auth.rootPassword=$MONGO_ROOT_PASSWORD,auth.username=$MONGO_USR,auth.password=$MONGO_PW" --version v12.1.20
 fi
 
 # kdevops.com
 helm install kdevops-website kdevops-website/ --values kdevops-website/values.yaml --set website_json_conf="`cat kdevops-website/website.json | base64`"
 
+# datadog monitoring
+if [ -z "$DDOG_API_KEY" ]; then
+  echo "Can't install datadog without an API key."
+else
+  helm install ddog --set datadog.apiKey=$DDOG_API_KEY datadog --version v2.36.0
+fi
 

--- a/kubernetes/charts/upgrade.sh
+++ b/kubernetes/charts/upgrade.sh
@@ -8,7 +8,18 @@ helm upgrade cert-manager cert-manager/ --namespace cert-manager --create-namesp
 # Trino, SQL at scale
 helm upgrade nt-trino trino/
 
+if [ -z "$MONGODB_ROOT_PASSWORD" -o -z "$MONGO_USR" -o -z "$MONGO_PW" ]; then
+  echo "Cowardly refusing to configure MongoDB without auth config."
+else
+  helm upgrade mongo001 mongodb/ --set "auth.rootPassword=$MONGO_ROOT_PASSWORD,auth.username=$MONGO_USR,auth.password=$MONGO_PW" --version v12.1.20
+fi
+
 # kdevops.com
 helm upgrade kdevops-website kdevops-website/ --values kdevops-website/values.yaml --set website_json_conf="`cat kdevops-website/website.json | base64`"
 
-
+# datadog monitoring
+if [ -z "$DDOG_API_KEY" ]; then
+  echo "Can't upgrade datadog without an API key."
+else
+  helm upgrade ddog --set datadog.apiKey=$DDOG_API_KEY datadog/ --version v2.36.0
+fi


### PR DESCRIPTION
It was very easy to integrate datadog. After installing the helm chart I see Kube cluster stats, logs, and more rolling to the web explorer.